### PR TITLE
Depend on qiskit directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.18.0
+qiskit>=0.32,<1
 requests>=2.19
 requests_ntlm>=1.1.0
 numpy>=1.13


### PR DESCRIPTION
### Summary

Currently, `qiskit-ibm-experiment` depends on `qiskit-terra`. Starting in Qiskit 1.0.0 only the `qiskit` package will be published. This PR changes the requirement to use `qiskit` instead of `qiskit-terra`.

### Details and comments

https://github.com/Qiskit/qiskit/pull/11230