### PR TITLE
Fix Qiskit dependency in package metadata

### DIFF
--- a/releasenotes/notes/qiskit-instead-of-qiskit-terra-ecda4531950f55e8.yaml
+++ b/releasenotes/notes/qiskit-instead-of-qiskit-terra-ecda4531950f55e8.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The dependency on Qiskit was changed from specifying ``qiskit-terra`` to
+    ``qiskit``.

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,20 @@ import os
 import setuptools
 
 REQUIREMENTS = [
-    "qiskit-terra>=0.18.0",
+    "qiskit-terra>=0.32,<1",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
     "numpy>=1.13",
     "urllib3>=1.21.1",
     "python-dateutil>=2.8.0",
-    "typing-extensions>=4.0.0",  # remove when support for Python 3.7 is dropped (use "from typing import" instead)
     "pandas>=1.3.0",
     "pyyaml>=6.0.0",
 ]
+REQUIREMENTS_PATH = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), "requirements.txt"
+)
+with open(REQUIREMENTS_PATH) as requirements_file:
+    REQUIREMENTS = requirements_file.read().splitlines()
 
 # Handle version.
 VERSION_PATH = os.path.join(
@@ -63,7 +67,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
`setup.py` was using its own list dependencies and not the list in `requirements.txt`. Here `setup.py` is changed to read `requirements.txt` so that the list is specified only once.

With this change, the intended change from 45eccf601182beea446feb59486d7e600cd77f6c of changing the Qiskit dependency from `qiskit-terra` to `qiskit` is also now applied to the package metadata.

Additionally, the dependency on `typing-extensions` was removed because it was only needed for Python 3.7 and `setup.py` already specified `python_requires>=3.8`.
