### PR TITLE
Add .zip format for artifact upload

### DIFF
--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -458,5 +458,7 @@ class ExperimentRestAdapter:
         if result.status_code == 200:
             if file_name.endswith(".yaml"):
                 return yaml.safe_load(result.content)
-            return result.json(cls=json_decoder)
+            elif file_name.endswith(".json"):
+                return result.json(cls=json_decoder)
+            return result.content
         return result

--- a/qiskit_ibm_experiment/client/local_client.py
+++ b/qiskit_ibm_experiment/client/local_client.py
@@ -798,4 +798,6 @@ class LocalExperimentClient:
             raise IBMExperimentEntryNotFound
         if file_name.endswith(".yaml"):
             return yaml.safe_load(self._files[experiment_id][file_name])
-        return json.loads(self._files[experiment_id][file_name], cls=json_decoder)
+        elif file_name.endswith(".json"):
+            return json.loads(self._files[experiment_id][file_name], cls=json_decoder)
+        return self._files[experiment_id][file_name]

--- a/qiskit_ibm_experiment/client/local_client.py
+++ b/qiskit_ibm_experiment/client/local_client.py
@@ -805,4 +805,4 @@ class LocalExperimentClient:
             return yaml.safe_load(self._files[experiment_id][file_name])
         elif file_name.endswith(".json"):
             return json.loads(self._files[experiment_id][file_name], cls=json_decoder)
-        return self._files[experiment_id][file_name]
+        return self._files[experiment_id][file_name].read()

--- a/qiskit_ibm_experiment/client/local_client.py
+++ b/qiskit_ibm_experiment/client/local_client.py
@@ -15,6 +15,7 @@
 # pylint treats the dataframes as JsonReader for some reason
 # pylint: disable=no-member
 
+import io
 import logging
 import os
 import uuid
@@ -767,9 +768,13 @@ class LocalExperimentClient:
             self._files_list[experiment_id] = []
         if experiment_id not in self._files:
             self._files[experiment_id] = {}
+        if isinstance(file_data, io.BytesIO):
+            size = len(file_data.getvalue())
+        else:
+            size = len(file_data)
         new_file_element = {
             "Key": file_name,
-            "Size": len(file_data),
+            "Size": size,
             "LastModified": str(datetime.now()),
         }
         self._files_list[experiment_id].append(new_file_element)

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1692,19 +1692,20 @@ class IBMExperimentService:
             json_encoder: Custom encoder to use to encode the experiment.
 
         Additional info:
-            The filename is expected to end with ".json" (otherwise it will be added)
+            The filename is expected to end with ".json", ".yaml", or ".zip", otherwise
+            ".json" will be added,
             and the data itself should be either a dictionary or a JSON serialization
             with the default encoder.
         """
-        # currently the resultdb enforces files to end with .json or .yaml
+        # currently resultdb enforces files to end with .json, .yaml, or .zip
         # without suffix, we assume json formatting
-        if not (file_name.endswith(".json") or file_name.endswith(".yaml")):
+        if not (file_name.endswith(".json") or file_name.endswith(".yaml") or file_name.endswith(".zip")):
             file_name += ".json"
         if isinstance(file_data, dict):
             # for now we avoid using custom encoder with yaml files
             if file_name.endswith(".yaml"):
                 file_data = yaml.dump(file_data)
-            else:
+            elif file_name.endswith(".zip"):
                 file_data = json.dumps(file_data, cls=json_encoder)
         self._api_client.experiment_file_upload(experiment_id, file_name, file_data)
 
@@ -1722,10 +1723,10 @@ class IBMExperimentService:
         Returns:
             The JSON deserialization of the data file
         Additional info:
-            The filename is expected to end with ".json", otherwise
-            it will be added.
+            The filename is expected to end with ".json", ".yaml", or ".zip", otherwise
+            ".json" will be added.
         """
-        if not (file_name.endswith(".json") or file_name.endswith(".yaml")):
+        if not (file_name.endswith(".json") or file_name.endswith(".yaml") or file_name.endswith(".zip")):
             file_name += ".json"
         # for now we avoid using custom decoder with yaml files
         file_data = self._api_client.experiment_file_download(

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1699,13 +1699,17 @@ class IBMExperimentService:
         """
         # currently resultdb enforces files to end with .json, .yaml, or .zip
         # without suffix, we assume json formatting
-        if not (file_name.endswith(".json") or file_name.endswith(".yaml") or file_name.endswith(".zip")):
+        if not (
+            file_name.endswith(".json")
+            or file_name.endswith(".yaml")
+            or file_name.endswith(".zip")
+        ):
             file_name += ".json"
         if isinstance(file_data, dict):
             # for now we avoid using custom encoder with yaml files
             if file_name.endswith(".yaml"):
                 file_data = yaml.dump(file_data)
-            elif file_name.endswith(".zip"):
+            elif file_name.endswith(".json"):
                 file_data = json.dumps(file_data, cls=json_encoder)
         self._api_client.experiment_file_upload(experiment_id, file_name, file_data)
 
@@ -1726,7 +1730,11 @@ class IBMExperimentService:
             The filename is expected to end with ".json", ".yaml", or ".zip", otherwise
             ".json" will be added.
         """
-        if not (file_name.endswith(".json") or file_name.endswith(".yaml") or file_name.endswith(".zip")):
+        if not (
+            file_name.endswith(".json")
+            or file_name.endswith(".yaml")
+            or file_name.endswith(".zip")
+        ):
             file_name += ".json"
         # for now we avoid using custom decoder with yaml files
         file_data = self._api_client.experiment_file_download(


### PR DESCRIPTION
### Summary

Required for https://github.com/Qiskit-Extensions/qiskit-experiments/pull/1342 since it would be computationally intensive to upload many artifact files for a composite experiment. Instead, artifacts will be zipped by type and uploaded as archives. The API already supports .zip formats.
