### PR TITLE
Include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE.txt README.md
+include LICENSE.txt README.md requirements.txt
 include qiskit_ibm_experiment/VERSION.txt
 recursive-include test *.py

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,6 @@ import os
 
 import setuptools
 
-REQUIREMENTS = [
-    "qiskit-terra>=0.32",
-    "requests>=2.19",
-    "requests-ntlm>=1.1.0",
-    "numpy>=1.13",
-    "urllib3>=1.21.1",
-    "python-dateutil>=2.8.0",
-    "pandas>=1.3.0",
-    "pyyaml>=6.0.0",
-]
 REQUIREMENTS_PATH = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "requirements.txt"
 )


### PR DESCRIPTION
The requirements.txt file is required to build the wheel from sdist because setup.py reads this file to get the dependencies. This file was missed in 9428c5f758fc00b15229aedf561c668ec1f4d1be.

Closes https://github.com/Qiskit-Extensions/qiskit-ibm-experiment/issues/92