### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/qiskit_ibm_experiment/client/session.py
+++ b/qiskit_ibm_experiment/client/session.py
@@ -17,7 +17,7 @@ import re
 import copy
 import logging
 from typing import List, Dict, Optional, Any, Tuple, Union
-import pkg_resources
+import importlib.metadata
 
 from requests import Session, RequestException, Response
 from requests.adapters import HTTPAdapter
@@ -49,7 +49,7 @@ RE_DEVICES_ENDPOINT = re.compile(r"^(.*/devices/)([^/}]{2,})(.*)$", re.IGNORECAS
 def _get_client_header() -> str:
     """Return the client version."""
     try:
-        client_header = "qiskit/" + pkg_resources.get_distribution("qiskit").version
+        client_header = "qiskit/" + importlib.metadata.distribution("qiskit").version
         return client_header
     except Exception:  # pylint: disable=broad-except
         pass
@@ -58,7 +58,7 @@ def _get_client_header() -> str:
     pkg_versions = {"qiskit-ibm-experiment": ibm_experiment_version}
     for pkg_name in qiskit_pkgs:
         try:
-            pkg_versions[pkg_name] = pkg_resources.get_distribution(pkg_name).version
+            pkg_versions[pkg_name] = importlib.metadata.distribution(pkg_name).version
         except Exception:  # pylint: disable=broad-except
             pass
     return ",".join(pkg_versions.keys()) + "/" + ",".join(pkg_versions.values())


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Replace the deprecated `pkg_resources.get_distrubtion` with the corresponding `importlib` functionality. See https://importlib-metadata.readthedocs.io/en/latest/migration.html#pkg-resources-get-distribution


