### PR TITLE
Add file_delete method to delete experiment file

### DIFF
--- a/qiskit_ibm_experiment/client/experiment.py
+++ b/qiskit_ibm_experiment/client/experiment.py
@@ -345,14 +345,14 @@ class ExperimentClient:
         """
         return self.api.file_download(experiment_id, file_name, json_decoder)
 
-    def experiment_file_delete(self, experiment_id: str, file_pathname: str):
+    def experiment_file_delete(self, experiment_id: str, file_name: str):
         """Deletes a data file from the DB
 
         Args:
             experiment_id: Experiment ID.
-            file_pathname: The path of the data file to delete.
+            file_name: The path of the data file to delete.
         """
-        return self.api.file_delete(experiment_id, file_pathname)
+        return self.api.file_delete(experiment_id, file_name)
 
     def device_components(self, backend_name: Optional[str]) -> List[Dict]:
         """Return device components for the backend.

--- a/qiskit_ibm_experiment/client/experiment.py
+++ b/qiskit_ibm_experiment/client/experiment.py
@@ -344,6 +344,15 @@ class ExperimentClient:
             The Dictionary of contents of the file
         """
         return self.api.file_download(experiment_id, file_name, json_decoder)
+    
+    def experiment_file_delete(self, experiment_id: str, file_pathname: str):
+        """Deletes a data file from the DB
+
+        Args:
+            experiment_id: Experiment ID.
+            file_pathname: The path of the data file to delete.
+        """
+        return self.api.file_delete(experiment_id, file_pathname)
 
     def device_components(self, backend_name: Optional[str]) -> List[Dict]:
         """Return device components for the backend.

--- a/qiskit_ibm_experiment/client/experiment.py
+++ b/qiskit_ibm_experiment/client/experiment.py
@@ -344,7 +344,7 @@ class ExperimentClient:
             The Dictionary of contents of the file
         """
         return self.api.file_download(experiment_id, file_name, json_decoder)
-    
+
     def experiment_file_delete(self, experiment_id: str, file_pathname: str):
         """Deletes a data file from the DB
 

--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -37,6 +37,7 @@ class ExperimentRestAdapter:
         "files": "/experiments/{uuid}/files",
         "files_upload": "/experiments/{uuid}/files/upload/{path}",
         "files_download": "/experiments/{uuid}/files/{path}",
+        "files_delete": "/experiments/{uuid}/files/{path}",
     }
 
     _HEADER_JSON_CONTENT = {"Content-Type": "application/json"}
@@ -462,3 +463,13 @@ class ExperimentRestAdapter:
                 return result.json(cls=json_decoder)
             return result.content
         return result
+    
+    def file_delete(self, experiment_id: str, file_pathname: str):
+        """Deletes a file from the DB
+        Args:
+            experiment_id: Experiment ID.
+            file_pathname: The path of the data file to delete.
+        """
+        url = self.get_url("files_delete")
+        url = url.format(uuid=experiment_id, path=file_pathname)
+        self.session.delete(url)

--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -464,12 +464,12 @@ class ExperimentRestAdapter:
             return result.content
         return result
 
-    def file_delete(self, experiment_id: str, file_pathname: str):
+    def file_delete(self, experiment_id: str, file_name: str):
         """Deletes a file from the DB
         Args:
             experiment_id: Experiment ID.
-            file_pathname: The path of the data file to delete.
+            file_name: The path of the data file to delete.
         """
         url = self.get_url("files_delete")
-        url = url.format(uuid=experiment_id, path=file_pathname)
+        url = url.format(uuid=experiment_id, path=file_name)
         self.session.delete(url)

--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -463,7 +463,7 @@ class ExperimentRestAdapter:
                 return result.json(cls=json_decoder)
             return result.content
         return result
-    
+
     def file_delete(self, experiment_id: str, file_pathname: str):
         """Deletes a file from the DB
         Args:

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1745,11 +1745,27 @@ class IBMExperimentService:
     def file_delete(self, experiment_id: str, file_pathname: str):
         """Deletes a data file from the DB
 
+        Note:
+            This method prompts for confirmation and requires a response before proceeding.
+        
         Args:
-            experiment_id: The experiment the data file belongs to
+            experiment_id: The experiment the data file belongs to.
             file_pathname: The path of the data file to delete.
+        
+        Raises:
+            IBMApiError: If the request to the server failed.
         """
-        self._api_client.experiment_file_delete(experiment_id, file_pathname)
+        if not self._confirm_delete(
+            "Are you sure you want to delete the experiment plot? [y/N]: "
+        ):
+            return
+        try:
+            self._api_client.experiment_file_delete(experiment_id, file_pathname)
+        except RequestsApiError as api_err:
+            if api_err.status_code == 404:
+                logger.warning("File %s not found.", file_pathname)
+            else:
+                raise IBMApiError(f"Failed to process the request: {api_err}") from None
 
     def experiment_has_file(self, experiment_id: str, file_name: str) -> bool:
         """Checks whether a specific expriment has a specific file

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1742,6 +1742,15 @@ class IBMExperimentService:
         )
         return file_data
 
+    def file_delete(self, experiment_id: str, file_pathname: str):
+        """Deletes a data file from the DB
+
+        Args:
+            experiment_id: The experiment the data file belongs to
+            file_pathname: The path of the data file to delete.
+        """
+        self._api_client.experiment_file_delete(experiment_id, file_pathname)
+
     def experiment_has_file(self, experiment_id: str, file_name: str) -> bool:
         """Checks whether a specific expriment has a specific file
         Args:

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1747,11 +1747,11 @@ class IBMExperimentService:
 
         Note:
             This method prompts for confirmation and requires a response before proceeding.
-        
+
         Args:
             experiment_id: The experiment the data file belongs to.
             file_pathname: The path of the data file to delete.
-        
+
         Raises:
             IBMApiError: If the request to the server failed.
         """

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1756,7 +1756,7 @@ class IBMExperimentService:
             IBMApiError: If the request to the server failed.
         """
         if not self._confirm_delete(
-            "Are you sure you want to delete the experiment plot? [y/N]: "
+            "Are you sure you want to delete the experiment file? [y/N]: "
         ):
             return
         try:

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1742,7 +1742,7 @@ class IBMExperimentService:
         )
         return file_data
 
-    def file_delete(self, experiment_id: str, file_pathname: str):
+    def file_delete(self, experiment_id: str, file_name: str):
         """Deletes a data file from the DB
 
         Note:
@@ -1750,7 +1750,7 @@ class IBMExperimentService:
 
         Args:
             experiment_id: The experiment the data file belongs to.
-            file_pathname: The path of the data file to delete.
+            file_name: The path of the data file to delete.
 
         Raises:
             IBMApiError: If the request to the server failed.
@@ -1760,10 +1760,10 @@ class IBMExperimentService:
         ):
             return
         try:
-            self._api_client.experiment_file_delete(experiment_id, file_pathname)
+            self._api_client.experiment_file_delete(experiment_id, file_name)
         except RequestsApiError as api_err:
             if api_err.status_code == 404:
-                logger.warning("File %s not found.", file_pathname)
+                logger.warning("File %s not found.", file_name)
             else:
                 raise IBMApiError(f"Failed to process the request: {api_err}") from None
 

--- a/releasenotes/notes/file-delete-4ca0baa574907813.yaml
+++ b/releasenotes/notes/file-delete-4ca0baa574907813.yaml
@@ -1,0 +1,5 @@
+---
+
+features:
+  - |
+    Added `file_delete` method to delete experiment artifacts.

--- a/releasenotes/notes/file-delete-4ca0baa574907813.yaml
+++ b/releasenotes/notes/file-delete-4ca0baa574907813.yaml
@@ -2,4 +2,4 @@
 
 features:
   - |
-    Added `file_delete` method to delete experiment artifacts.
+    Added the :meth:`~IBMExperimentService.file_delete` method to delete experiment artifacts.


### PR DESCRIPTION
Implemented `file_delete` service function to delete an artifact file of an experiment.