### PR TITLE
Update service tests

### DIFF
--- a/test/service/test_experiment_data_integration.py
+++ b/test/service/test_experiment_data_integration.py
@@ -82,7 +82,7 @@ class TestExperimentDataIntegration(IBMTestCase):
             url=os.getenv("QISKIT_IBM_STAGING_API_URL"),
             instance=os.getenv("QISKIT_IBM_STAGING_HGP"),
         )
-        cls.backend = cls.provider.get_backend(os.getenv("QISKIT_IBM_STAGING_BACKEND"))
+        cls.backend = cls.provider.backend(os.getenv("QISKIT_IBM_STAGING_BACKEND"))
         try:
             cls.device_components = cls.service.device_components(cls.backend.name)
         except IBMApiError:

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -68,7 +68,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             url=os.getenv("QISKIT_IBM_STAGING_API_URL"),
             instance=os.getenv("QISKIT_IBM_STAGING_HGP"),
         )
-        cls.backend = cls.provider.get_backend(os.getenv("QISKIT_IBM_STAGING_BACKEND"))
+        cls.backend = cls.provider.backend(os.getenv("QISKIT_IBM_STAGING_BACKEND"))
         try:
             cls.device_components = cls.service.device_components(cls.backend.name)
         except IBMApiError:


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `get_backend` method of `QiskitRuntimeService` is deprecated and `backend` should be used instead, so I updated this in  
`test_experiment_server_integration.py` and `test_experiment_data_integration.py`.


